### PR TITLE
Made it so the URL for the `handle_upload` view is dynamic

### DIFF
--- a/trix_editor/urls.py
+++ b/trix_editor/urls.py
@@ -4,5 +4,5 @@ from trix_editor.views import handle_upload
 
 
 urlpatterns = [
-    path('upload/', handle_upload, name='upload'),
+    path('upload/', handle_upload, name='trix_editor_upload'),
 ]

--- a/trix_editor/widgets.py
+++ b/trix_editor/widgets.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.conf import settings
+from django.urls import reverse
 from django.utils.safestring import mark_safe
 
 TRIX_VERSION = getattr(settings, 'TRIX_VERSION', '2.1.0')
@@ -56,7 +57,7 @@ class JSCode:
                     var xhr = new XMLHttpRequest()
                     formData.append("Content-Type", file.type)
                     formData.append("file", file)
-                    xhr.open("POST", "/trix-editor/upload/", true)
+                    xhr.open("POST", \"""" + reverse('trix_editor_upload') + """", true)
                     xhr.setRequestHeader("X-CSRFToken", getCookie("csrftoken"))
                     xhr.upload.addEventListener("progress", function (event) {
                         progressCallback(event.loaded / event.total * 100)


### PR DESCRIPTION
Some of the sites I work on are set up to use Django only for URLs beginning with `/admin/` or `/api/`, so I would like to be able to have a custom URL for the `handle_upload` view.